### PR TITLE
 Require a BufRead instead of Read

### DIFF
--- a/src/fs_annot.rs
+++ b/src/fs_annot.rs
@@ -7,7 +7,7 @@
 use byteordered::{ByteOrdered};
 
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, BufRead};
 use std::path::{Path};
 use std::fmt;
 
@@ -31,7 +31,7 @@ impl FsAnnotColortable {
     /// Read a colortable in format version 2 from a reader. The reader must be at the start position of the colortable.
     pub fn from_reader<S>(input: &mut S) -> Result<FsAnnotColortable>
     where
-        S: Read,
+        S: BufRead,
     {
         let mut input = ByteOrdered::be(input);
 

--- a/src/fs_mgh.rs
+++ b/src/fs_mgh.rs
@@ -7,7 +7,7 @@ use ndarray::{Array, Array1, Array2, Array4, Dim, array};
 
 
 use std::{fs::File};
-use std::io::{BufReader, Read, BufWriter, Write};
+use std::io::{BufReader, BufRead, BufWriter, Write};
 use std::path::{Path};
 use std::fmt;
 
@@ -86,7 +86,7 @@ impl FsMghHeader {
         let mut file = BufReader::new(File::open(path)?);
 
         if gz {
-            FsMghHeader::from_reader(&mut GzDecoder::new(file))
+            FsMghHeader::from_reader(&mut BufReader::new(GzDecoder::new(file)))
         } else {
             FsMghHeader::from_reader(&mut file)
         }
@@ -97,7 +97,7 @@ impl FsMghHeader {
     /// Read an MGH header from the given byte stream.
     /// It is assumed that the input is currently at the start of the
     /// header.
-    pub fn from_reader<S>(input: &mut S) -> Result<FsMghHeader> where S: Read,
+    pub fn from_reader<S>(input: &mut S) -> Result<FsMghHeader> where S: BufRead,
     {
         let mut hdr = FsMghHeader::default();
     
@@ -206,7 +206,7 @@ impl FsMgh {
 
         let data = 
         if gz {
-            FsMgh::data_from_reader(&mut GzDecoder::new(file), &hdr)?
+            FsMgh::data_from_reader(&mut BufReader::new(GzDecoder::new(file)), &hdr)?
         } else {
             FsMgh::data_from_reader(&mut file, &hdr)?
         };
@@ -220,7 +220,7 @@ impl FsMgh {
 
 
     /// Read MGH data from a reader. It is assumed that position is before the header.
-    pub fn data_from_reader<S>(file: &mut S, hdr: &FsMghHeader) -> Result<FsMghData> where S: Read, {
+    pub fn data_from_reader<S>(file: &mut S, hdr: &FsMghHeader) -> Result<FsMghData> where S: BufRead, {
 
         let vol_dim = Dim([hdr.dim1len as usize, hdr.dim2len as usize, hdr.dim3len as usize, hdr.dim4len as usize]);
 

--- a/src/fs_surface.rs
+++ b/src/fs_surface.rs
@@ -8,7 +8,7 @@
 use byteordered::{ByteOrdered, Endianness};
 
 use std::{fs::File};
-use std::io::{BufReader, BufRead, Read, BufWriter, Write};
+use std::io::{BufReader, BufRead, BufWriter, Write};
 use std::path::{Path};
 use std::fmt;
 
@@ -57,7 +57,7 @@ impl FsSurfaceHeader {
     /// FsSurface header.
     pub fn from_reader<S>(input: &mut S) -> Result<FsSurfaceHeader>
     where
-        S: Read,
+        S: BufRead,
     {
         let mut hdr = FsSurfaceHeader::default();
     
@@ -378,7 +378,7 @@ impl FsSurface {
     /// Read a brain mesh, i.e., the data part of an FsSurface instance, from a reader.
     pub fn mesh_from_reader<S>(input: &mut S, hdr: &FsSurfaceHeader) -> BrainMesh
     where
-        S: Read,
+        S: BufRead,
     {
     
         let mut input = ByteOrdered::be(input);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 //! Utility functions used in all other neuroformats modules.
 
 use std::{path::Path};
-use std::io::{Read};
+use std::io::{BufRead};
 
 use crate::error::{Result};
 
@@ -25,7 +25,7 @@ pub fn is_gz_file<P>(path: P) -> bool where P: AsRef<Path>, {
 /// * Terrible things will happen if the input does not contain a sequence of two consecutive `\x0A` chars.
 pub fn read_fs_variable_length_string<S>(input: &mut S) -> Result<String>
     where
-        S: Read,
+        S: BufRead,
     {
         let mut last_char;
         let mut cur_char : char = '0';
@@ -47,7 +47,7 @@ pub fn read_fs_variable_length_string<S>(input: &mut S) -> Result<String>
 /// Read a fixed length zero-terminated byte string of the given length from the input. The `len` value must include the trailing NUL byte position, if any. Embedded '\0' chars are allowed, and the trailing one (if any) is read but not added to the returned String (all others are).
 pub fn read_fixed_length_string<S>(input: &mut S, len: usize) -> Result<String>
 where
-    S: Read,
+    S: BufRead,
 {
     let mut info_line = String::with_capacity(len);
     for char_idx  in 0..len   {
@@ -181,7 +181,7 @@ mod test {
 
     #[test]
     fn a_fixed_length_without_termination_char_can_be_read() {
-        use std::io::{Cursor, Seek, SeekFrom, Write};
+        use std::io::{Cursor, Read, Seek, SeekFrom, Write};
     
         // Create our "file".
         let mut c = Cursor::new(Vec::<u8>::new());


### PR DESCRIPTION
Reading u8, u16, etc directly from a file is very slow and inefficient, a BuRead makes this process much faster and efficient.

Having a function that receive a generic `Read`, then creating a `BufReader` from it could be problematic, because if the user call this function with a type that already implement `BufRead`, then we will double buffer the data.