### PR TITLE
Convert Struct of Vectors into Vector of Structs

### DIFF
--- a/src/fs_annot.rs
+++ b/src/fs_annot.rs
@@ -194,7 +194,7 @@ impl FsAnnot {
     /// annot.vertex_regions();
     /// ```
     pub fn vertex_regions(&self) -> Vec<String> {
-        let mut vert_regions: Vec<String> = Vec::with_capacity(self.vertex_labels.len());
+        let mut vert_regions: Vec<String> = vec![String::new(); self.vertex_labels.len()];
         for region in self.colortable.regions.iter() {
             let region_label = region.label;
             let region_name = &region.name;

--- a/src/fs_curv.rs
+++ b/src/fs_curv.rs
@@ -93,7 +93,8 @@ pub struct FsCurv {
 
 impl fmt::Display for FsCurv {    
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {        
-        write!(f, "Per-vertex data for {} vertices, with values in range {} to {}.", self.data.len(), vec32minmax(&self.data, false).0, vec32minmax(&self.data, false).1)
+        let (min, max) = vec32minmax(self.data.iter().copied(), false);
+        write!(f, "Per-vertex data for {} vertices, with values in range {} to {}.", self.data.len(), min, max)
     }
 }
 
@@ -200,7 +201,7 @@ mod test {
         assert_eq!(149244, curv.data.len());        
 
         use crate::util::vec32minmax;
-        let (min, max) = vec32minmax(&curv.data, false);
+        let (min, max) = vec32minmax(curv.data.into_iter(), false);
         assert_abs_diff_eq!(0.0, min, epsilon = 1e-10);
         assert_abs_diff_eq!(5.0, max, epsilon = 1e-10);
     }
@@ -224,7 +225,7 @@ mod test {
         assert_eq!(149244, curv_re.data.len());        
 
         use crate::util::vec32minmax;
-        let (min, max) = vec32minmax(&curv_re.data, false);
+        let (min, max) = vec32minmax(curv_re.data.into_iter(), false);
         assert_abs_diff_eq!(0.0, min, epsilon = 1e-10);
         assert_abs_diff_eq!(5.0, max, epsilon = 1e-10);
     }

--- a/src/fs_label.rs
+++ b/src/fs_label.rs
@@ -92,6 +92,20 @@ pub struct FsLabelVertex {
     pub value: f32,
 }
 
+// Read a FsLabelVertex from a line.
+impl std::str::FromStr for FsLabelVertex {
+    type Err = NeuroformatsError;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let mut iter = s.split_whitespace();
+        let index = iter.next().unwrap().parse::<i32>().expect("Expected vertex index of type i32.");
+        let coord1 = iter.next().unwrap().parse::<f32>().expect("Expected coord1 of type f32.");
+        let coord2 = iter.next().unwrap().parse::<f32>().expect("Expected coord2 of type f32.");
+        let coord3 = iter.next().unwrap().parse::<f32>().expect("Expected coord3 of type f32.");
+        let value = iter.next().unwrap().parse::<f32>().expect("Expected vertex value of type f32.");
+        Ok(FsLabelVertex{ index, coord1, coord2, coord3, value })
+    }
+}
+
 /// Read a surface label or volume label from a file in FreeSurfer label format.
 ///
 /// A label groups a number of vertices (for surface label) or voxels (for volume labels) together. It can
@@ -117,13 +131,8 @@ pub fn read_label<P: AsRef<Path>>(path: P) -> Result<FsLabel> {
     let mut vertexes = Vec::with_capacity(hdr_num_entries as usize);
     for line in lines {
         let line = line?;
-        let mut iter = line.split_whitespace();
-        let index = iter.next().unwrap().parse::<i32>().expect("Expected vertex index of type i32.");
-        let coord1 = iter.next().unwrap().parse::<f32>().expect("Expected coord1 of type f32.");
-        let coord2 = iter.next().unwrap().parse::<f32>().expect("Expected coord2 of type f32.");
-        let coord3 = iter.next().unwrap().parse::<f32>().expect("Expected coord3 of type f32.");
-        let value = iter.next().unwrap().parse::<f32>().expect("Expected vertex value of type f32.");
-        vertexes.push(FsLabelVertex{ index, coord1, coord2, coord3, value });
+        let vertex = line.parse()?;
+        vertexes.push(vertex);
     }
 
     if hdr_num_entries as usize != vertexes.len() {


### PR DESCRIPTION
This PR convert the structs `FsAnnotColortable` and `FsLabel` from "Struct composed of Vectors" into "A Vector that contains Structs".

A "Struct of Vectors" can be faster in some edge cases, but it is usually not, due to the memory fragmentation and how modern CPU handles cache. Also a "Vectors of Structs" have a significant number of advantages:

* Using a vector of structs can provide a simpler and more intuitive representation of the data.
* When using a vector of structs, adding or removing entities is straightforward.
* Improved memory locality: which can improve cache performance and reduce memory access overhead.

I tried to keep changes to a minimum, replacing only the code related to those structs, but it was necessary to rewrite the function `vec32minmax` and `vertex_regions` to fix #3 and #4.

There is no benchmark included in this repo, so I could not test for changes in performance, but I assume there is none or very little change in speed.