### PR TITLE
Add benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ features = ["approx"]
 
 [dev-dependencies]
 tempfile = "3.2.0"
+criterion = "0.4"
+
+[[bench]]
+name = "benchmark"
+harness = false
 
 [profile.dev]
 opt-level = 3

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,0 +1,58 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use neuroformats::{
+    read_annot, read_curv, read_label, read_mgh, read_surf, FsAnnot, FsCurv, FsLabel, FsMgh,
+    FsSurface,
+};
+
+fn fs_annot(file: &str) -> FsAnnot {
+    read_annot(file).unwrap()
+}
+
+fn fs_curv(file: &str) -> FsCurv {
+    read_curv(file).unwrap()
+}
+
+fn fs_label(file: &str) -> FsLabel {
+    read_label(file).unwrap()
+}
+
+fn fs_mgh(file: &str) -> FsMgh {
+    read_mgh(file).unwrap()
+}
+
+fn fs_surf(file: &str) -> FsSurface {
+    read_surf(file).unwrap()
+}
+
+fn bench_read(c: &mut Criterion) {
+    c.bench_function("fs_annot", |b| {
+        b.iter(|| {
+            fs_annot(black_box(
+                "resources/subjects_dir/subject1/label/lh.aparc.annot",
+            ))
+        })
+    });
+    c.bench_function("fs_curv", |b| {
+        b.iter(|| {
+            fs_curv(black_box(
+                "resources/subjects_dir/subject1/surf/lh.thickness",
+            ))
+        })
+    });
+    c.bench_function("fs_label", |b| {
+        b.iter(|| {
+            fs_label(black_box(
+                "resources/subjects_dir/subject1/label/lh.entorhinal_exvivo.label",
+            ))
+        })
+    });
+    c.bench_function("fs_mgh", |b| {
+        b.iter(|| fs_mgh(black_box("resources/subjects_dir/subject1/mri/brain.mgz")))
+    });
+    c.bench_function("fs_surf", |b| {
+        b.iter(|| fs_surf(black_box("resources/subjects_dir/subject1/surf/lh.white")))
+    });
+}
+
+criterion_group!(benches, bench_read);
+criterion_main!(benches);


### PR DESCRIPTION
It uses [criterion](https://crates.io/crates/criterion), the `read_*` functions and the files from `subject1` to execute some baseline benchmark.

This is not particularly accurate because the file read is done inside the benchmark, and not cached prior, but it could be fixed by creating `from_reader` for all the `Fs*` structs.

In any case, it could be a first step and should be able to detect big performance regressions, AKA bigger then 25%.